### PR TITLE
[open-swe] feat: Add conditional routing logic to LangGraph agent for proper tool usage

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -15,7 +15,7 @@ from langchain_tavily import TavilySearch
 from langgraph.graph import StateGraph, START, END
 from langgraph.graph.message import add_messages
 from langgraph.checkpoint.memory import InMemorySaver
-from langgraph.prebuilt import ToolNode
+from langgraph.prebuilt import ToolNode, tools_condition
 
 # Load environment variables
 load_dotenv()
@@ -84,10 +84,14 @@ def create_agent():
     workflow.add_node("agent", agent_node)
     workflow.add_node("tools", tool_node)
     
-    # Add basic edges
+    # Add edges
     workflow.add_edge(START, "agent")
+    
+    # Add conditional routing: check if agent response has tool_calls
+    workflow.add_conditional_edges("agent", tools_condition)
+    
+    # After tools execute, return to agent for final response
     workflow.add_edge("tools", "agent")
-    workflow.add_edge("agent", END)
     
     # Add memory checkpointer
     checkpointer = InMemorySaver()
@@ -97,12 +101,12 @@ def create_agent():
     
     return app
 
-app = create_agent()
+compiled_graph = create_agent()
 
 def test_agent():
     """Test the agent with various query types."""
     
-    agent = app
+    agent = compiled_graph
     
     test_cases = [
         "What's the weather in New York?",


### PR DESCRIPTION
Fixes #9

This PR implements conditional routing logic for the LangGraph agent to properly handle tool usage decisions.

## Changes Made

- **Added conditional routing**: Replaced direct edge from 'agent' to END with `tools_condition` logic that routes to 'tools' node when tool_calls are present, or to END for direct answers
- **Imported tools_condition**: Added `tools_condition` from `langgraph.prebuilt` for robust tool call detection
- **Updated graph export**: Changed variable name from 'app' to 'compiled_graph' to meet evaluation requirements

## Functionality

The agent now properly:
- Uses tools for weather queries, math calculations, and knowledge searches
- Provides direct answers for simple conversational queries
- Cycles between agent decisions and tool usage (agent → tools → agent → END)

The implementation leverages LangGraph's prebuilt `tools_condition` function for reliable routing based on the presence of tool_calls in the agent's response.